### PR TITLE
support for extra tool at end effector, plot improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ The result:
 
 ![](https://github.com/dbddqy/visual_kinematics/blob/master/pics/trajectory.gif?raw=true)
 
+## trajectory_from_joints . py
+
+A trajectory can also be visualized when the joint angles for all frames are known beforehand:
+
+```python
+slider = RobotTrajectory.draw_from_joint_positions(robot, thetas)
+```
+This results in the same visualization as the trajectory made by interpolating frames (see above).
+
+By saving the return value you ensure that the slider is not getting garbage collected.
+
 ## analytical_inv . py
 
 While defining the robot, we can set an analytical solution for solving its inverse kinematics.

--- a/examples/7_axis.py
+++ b/examples/7_axis.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-
-from visual_kinematics.RobotSerial import *
-from visual_kinematics.RobotTrajectory import *
-import numpy as np
 from math import pi
+
+import numpy as np
+
+from visual_kinematics import Frame
+from visual_kinematics.RobotSerial import RobotSerial
+from visual_kinematics.RobotTrajectory import RobotTrajectory
 
 
 def main():

--- a/examples/analytical_inv.py
+++ b/examples/analytical_inv.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
+from math import atan2, cos, pi, sin, sqrt
 
-from visual_kinematics.RobotSerial import *
-from visual_kinematics.RobotTrajectory import *
 import numpy as np
-from math import pi, sqrt, sin, cos, atan2
+
+from visual_kinematics import Frame
+from visual_kinematics.RobotSerial import RobotSerial
+from visual_kinematics.RobotTrajectory import RobotTrajectory
 
 
 def main():

--- a/examples/delta_trajectory.py
+++ b/examples/delta_trajectory.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
-from visual_kinematics.RobotDelta import *
-from visual_kinematics.RobotTrajectory import *
 import numpy as np
+
+from visual_kinematics.Frame import Frame
+from visual_kinematics.RobotDelta import RobotDelta
+from visual_kinematics.RobotTrajectory import RobotTrajectory
 
 
 def main():

--- a/examples/delta_workspace.py
+++ b/examples/delta_workspace.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
-
-from visual_kinematics.RobotDelta import *
 from math import pi
+
+import numpy as np
+
+from visual_kinematics.RobotDelta import RobotDelta
 
 
 def main():

--- a/examples/forward.py
+++ b/examples/forward.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
-from visual_kinematics.RobotSerial import *
-import numpy as np
 from math import pi
+
+import numpy as np
+
+from visual_kinematics.RobotSerial import RobotSerial
 
 
 def main():

--- a/examples/inverse.py
+++ b/examples/inverse.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
-from visual_kinematics.RobotSerial import *
-import numpy as np
 from math import pi
+
+import numpy as np
+
+from visual_kinematics.Frame import Frame
+from visual_kinematics.RobotSerial import RobotSerial
 
 
 def main():

--- a/examples/plot_options.py
+++ b/examples/plot_options.py
@@ -1,0 +1,86 @@
+from copy import copy
+
+import numpy as np
+from matplotlib import pyplot as plt
+
+from visual_kinematics.RobotSerial import RobotSerial
+from visual_kinematics.Tool import Tool
+
+
+def test_draw():
+    # robot dh parameters (ur5, in m)
+    dh_params = np.array(
+        [
+            [0.089159, 0.0, np.pi / 2, 0.0],
+            [0.0, -0.4250, 0.0, 0.0],
+            [0.0, -0.39225, 0.0, 0.0],
+            [0.10915, 0.0, np.pi / 2, 0.0],
+            [0.09465, 0.0, -np.pi / 2, 0.0],
+            [0.0823, 0.0, 0.0, 0.0],
+        ]
+    )
+    # tool - rotate from [0, 0, 1] to [1, 1, 1], translate 0.05m in y, 0.1m in z
+    sqrt_3_inv = 1 / np.sqrt(3)
+    t_4_4 = np.array(
+        [
+            [0.5 + 0.5 * sqrt_3_inv, -0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0],
+            [-0.5 + 0.5 * sqrt_3_inv, 0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0.050],
+            [-sqrt_3_inv, -sqrt_3_inv, sqrt_3_inv, 0.100],
+            [0, 0, 0, 1],
+        ]
+    )
+    tool = Tool(t_4_4)
+
+    joint_angles = np.array([1, -2, 2, 1, 1, 1])
+
+    draw_without_tool(joint_angles, dh_params)
+    draw_with_tool_auto_zoom(joint_angles, dh_params, tool)
+    draw_distorted_without_markers(joint_angles, dh_params)
+
+    plt.show()
+
+
+def draw_without_tool(joint_angles, dh_params):
+    robot_no_tool = RobotSerial(
+        dh_params=dh_params,
+        dh_type="normal",
+        ws_lim=None,
+    )
+    robot_no_tool.forward(joint_angles)
+    robot_no_tool.draw()
+
+
+def draw_distorted_without_markers(joint_angles, dh_params):
+    robot_specify_plot_size = RobotSerial(
+        dh_params=dh_params,
+        dh_type="normal",
+        plot_xlim=(-0.2, 0.1),
+        plot_ylim=(-1, 1),
+        plot_zlim=(0, 0.5),
+        ws_lim=None,
+    )
+    robot_specify_plot_size.forward(joint_angles)
+    robot_specify_plot_size.draw(
+        cylinder_relative_size=0, orientation_relative_size=0
+    )
+
+
+def draw_with_tool_auto_zoom(joint_angles, dh_params, tool):
+    # convert to mm so it does not fit in the default plot window
+    dh_in_mm = copy(dh_params)
+    dh_in_mm[:, :2] = 1000 * dh_in_mm[:, :2]
+    robot_with_tool = RobotSerial(
+        dh_params=dh_in_mm,
+        dh_type="normal",
+        tool=tool,
+        plot_xlim=None,
+        plot_ylim=None,
+        plot_zlim=None,
+        ws_lim=None,
+    )
+    robot_with_tool.forward(joint_angles)
+    robot_with_tool.draw()
+
+
+if __name__ == "__main__":
+    test_draw()

--- a/examples/plot_options.py
+++ b/examples/plot_options.py
@@ -19,13 +19,13 @@ def test_draw():
             [0.0823, 0.0, 0.0, 0.0],
         ]
     )
-    # tool - rotate from [0, 0, 1] to [1, 1, 1], translate 0.05m in y, 0.1m in z
+    # tool - rotate from [0, 0, 1] to [1, 1, 1], translate 50mm in y, 100mm in z
     sqrt_3_inv = 1 / np.sqrt(3)
     t_4_4 = np.array(
         [
             [0.5 + 0.5 * sqrt_3_inv, -0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0],
-            [-0.5 + 0.5 * sqrt_3_inv, 0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0.050],
-            [-sqrt_3_inv, -sqrt_3_inv, sqrt_3_inv, 0.100],
+            [-0.5 + 0.5 * sqrt_3_inv, 0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 50],
+            [-sqrt_3_inv, -sqrt_3_inv, sqrt_3_inv, 100],
             [0, 0, 0, 1],
         ]
     )

--- a/examples/trajectory.py
+++ b/examples/trajectory.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
-from visual_kinematics.RobotSerial import *
-from visual_kinematics.RobotTrajectory import *
-import numpy as np
 from math import pi
+
+import numpy as np
+
+from visual_kinematics.Frame import Frame
+from visual_kinematics.RobotSerial import RobotSerial
+from visual_kinematics.RobotTrajectory import RobotTrajectory
 
 
 def main():

--- a/examples/trajectory_from_joints.py
+++ b/examples/trajectory_from_joints.py
@@ -35,19 +35,19 @@ def test_draw_with_slider():
         tool=Tool(t_4_4),
         ws_lim=None,
     )
-    numberOfPositions = 100
-    joint_angles = np.array(
+    number_of_positions = 100
+    thetas = np.array(
         [
-            np.arange(-1, -3, -2 / numberOfPositions),
-            np.arange(-2, 0, 2 / numberOfPositions),
-            np.arange(2, -2, -4 / numberOfPositions),
-            np.arange(-2, -1, 1 / numberOfPositions),
-            np.arange(3, 0, -3 / numberOfPositions),
-            np.arange(-3, 3, 6 / numberOfPositions),
+            np.arange(-1, -3, -2 / number_of_positions),
+            np.arange(-2, 0, 2 / number_of_positions),
+            np.arange(2, -2, -4 / number_of_positions),
+            np.arange(-2, -1, 1 / number_of_positions),
+            np.arange(3, 0, -3 / number_of_positions),
+            np.arange(-3, 3, 6 / number_of_positions),
         ]
     ).T
 
-    slider = RobotTrajectory.draw_from_joint_positions(robot, joint_angles)
+    slider = RobotTrajectory.draw_from_joint_positions(robot, thetas)
 
     plt.show()
 

--- a/examples/trajectory_from_joints.py
+++ b/examples/trajectory_from_joints.py
@@ -1,0 +1,56 @@
+import numpy as np
+from matplotlib import pyplot as plt
+
+from visual_kinematics.RobotSerial import RobotSerial
+from visual_kinematics.RobotTrajectory import RobotTrajectory
+from visual_kinematics.Tool import Tool
+
+
+def test_draw_with_slider():
+    # robot dh parameters (ur5, in m)
+    dh_params = np.array(
+        [
+            [0.089159, 0.0, np.pi / 2, 0.0],
+            [0.0, -0.4250, 0.0, 0.0],
+            [0.0, -0.39225, 0.0, 0.0],
+            [0.10915, 0.0, np.pi / 2, 0.0],
+            [0.09465, 0.0, -np.pi / 2, 0.0],
+            [0.0823, 0.0, 0.0, 0.0],
+        ]
+    )
+    # tool - rotate from [0, 0, 1] to [1, 1, 1], translate 0.05m in y, 0.1m in z
+    sqrt_3_inv = 1 / np.sqrt(3)
+    t_4_4 = np.array(
+        [
+            [0.5 + 0.5 * sqrt_3_inv, -0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0],
+            [-0.5 + 0.5 * sqrt_3_inv, 0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0.050],
+            [-sqrt_3_inv, -sqrt_3_inv, sqrt_3_inv, 0.100],
+            [0, 0, 0, 1],
+        ]
+    )
+
+    robot = RobotSerial(
+        dh_params=dh_params,
+        dh_type="normal",
+        tool=Tool(t_4_4),
+        ws_lim=None,
+    )
+    numberOfPositions = 100
+    joint_angles = np.array(
+        [
+            np.arange(-1, -3, -2 / numberOfPositions),
+            np.arange(-2, 0, 2 / numberOfPositions),
+            np.arange(2, -2, -4 / numberOfPositions),
+            np.arange(-2, -1, 1 / numberOfPositions),
+            np.arange(3, 0, -3 / numberOfPositions),
+            np.arange(-3, 3, 6 / numberOfPositions),
+        ]
+    ).T
+
+    slider = RobotTrajectory.draw_from_joint_positions(robot, joint_angles)
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    test_draw_with_slider()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="visual_kinematics",
-    version="0.3.0",
+    version="0.2.1",
     author="Yue QI",
     author_email="dbddqy@outlook.com",
     description="A package for calculating robot kinematics and visualizing trajectory",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="visual_kinematics",
-    version="0.2.1",
+    version="0.3.0",
     author="Yue QI",
     author_email="dbddqy@outlook.com",
     description="A package for calculating robot kinematics and visualizing trajectory",
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/dbddqy/visual_kinematics",
     packages=setuptools.find_packages(),
-    keywords = ['robotics', ' kinematics', 'inverse kinematics', 'trajectory planning', 'visualization'],
+    keywords=['robotics', ' kinematics', 'inverse kinematics', 'trajectory planning', 'visualization'],
     install_requires=[
         'numpy',
         'scipy',

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -41,8 +41,25 @@ class TestRobotSerial(TestCase):
 
     def test_draw(self):
         joint_angles = np.array([1, 1, 1, 1, 1, 1])
-        self.robot_with_tool.forward(joint_angles)
-        self.robot_with_tool.draw()
 
-        self.robot_no_tool.forward(joint_angles)
-        self.robot_no_tool.show()
+        with self.subTest('without tool'):
+            self.robot_no_tool.forward(joint_angles)
+            self.robot_no_tool.show()
+
+        with self.subTest('with tool'):
+            self.robot_with_tool.forward(joint_angles)
+            self.robot_with_tool.draw()
+
+    def test_inverse(self):
+        joint_angles_exp = np.array([1, 1, 1, 1, 1, 1])
+
+        with self.subTest('without tool'):
+            end_frame = self.robot_no_tool.forward(joint_angles_exp)
+            joint_angles = self.robot_no_tool.inverse(end_frame)
+            [self.assertAlmostEqual(joint_angle, joint_angle_exp) for joint_angle, joint_angle_exp in zip(joint_angles, joint_angles_exp)]
+
+        with self.subTest('with tool'):
+            end_frame = self.robot_with_tool.forward(joint_angles_exp)
+            joint_angles = self.robot_with_tool.inverse(end_frame)
+            [self.assertAlmostEqual(joint_angle, joint_angle_exp) for joint_angle, joint_angle_exp in zip(joint_angles, joint_angles_exp)]
+

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -36,6 +36,7 @@ class TestRobotSerial(TestCase):
         joint_angles = np.array([1, -2, 2, 1, 1, 1])
 
         with self.subTest("without tool"):
+            # convert to m so it fits in the default plot window
             dh_in_m = copy(self.dh_params)
             dh_in_m[:, :2] = 0.001 * dh_in_m[:, :2]
             robot_no_tool = RobotSerial(
@@ -46,7 +47,7 @@ class TestRobotSerial(TestCase):
             robot_no_tool.forward(joint_angles)
             robot_no_tool.draw()
 
-        with self.subTest("with tool"):
+        with self.subTest("with tool, use auto zoom"):
             robot_with_tool = RobotSerial(
                 dh_params=self.dh_params,
                 dh_type="normal",
@@ -59,9 +60,7 @@ class TestRobotSerial(TestCase):
             robot_with_tool.forward(joint_angles)
             robot_with_tool.draw()
 
-        with self.subTest(
-            "plot size specified (distorted), remove cylinders and orientation markers"
-        ):
+        with self.subTest("plot size specified (distorted), remove cylinders and orientation markers"):
             robot_specify_plot_size = RobotSerial(
                 dh_params=self.dh_params,
                 dh_type="normal",

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -59,9 +59,9 @@ class TestRobotSerial(TestCase):
             self.robot_with_tool.forward(joint_angles)
             self.robot_with_tool.draw()
 
-        with self.subTest('plot size specified (distorted)'):
+        with self.subTest('plot size specified (distorted), remove cylinders and orientation markers'):
             self.robot_specify_plot_size.forward(joint_angles)
-            self.robot_specify_plot_size.draw()
+            self.robot_specify_plot_size.draw(cylinder_relative_size=0, orientation_relative_size=0)
 
         plt.show()
 

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -36,10 +36,10 @@ class TestRobotSerial(TestCase):
         joint_angles = np.array([1, -2, 2, 1, 1, 1])
 
         with self.subTest("without tool"):
-            dh_in_mm = copy(self.dh_params)
-            dh_in_mm[:, :2] = 0.001 * dh_in_mm[:, :2]
+            dh_in_m = copy(self.dh_params)
+            dh_in_m[:, :2] = 0.001 * dh_in_m[:, :2]
             robot_no_tool = RobotSerial(
-                dh_params=dh_in_mm,
+                dh_params=dh_in_m,
                 dh_type="normal",
                 ws_lim=None,
             )

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 
 import numpy as np
 from matplotlib import pyplot as plt
-from matplotlib.widgets import Slider
 
 from visual_kinematics.RobotSerial import RobotSerial
 from visual_kinematics.Tool import Tool
@@ -73,46 +72,6 @@ class TestRobotSerial(TestCase):
             robot_specify_plot_size.draw(
                 cylinder_relative_size=0, orientation_relative_size=0
             )
-
-        plt.show()
-
-    def test_draw_with_slider(self):
-        robot = RobotSerial(
-            dh_params=self.dh_params,
-            dh_type="normal",
-            tool=Tool(self.t_4_4),
-            plot_xlim=None,
-            plot_ylim=None,
-            plot_zlim=None,
-            ws_lim=None,
-        )
-        numberOfPositions = 100
-        joint_angles = np.array(
-            [
-                np.arange(1, 2, 1 / numberOfPositions),
-                np.arange(-2, 0, 2 / numberOfPositions),
-                np.arange(2, 1, -1 / numberOfPositions),
-                np.arange(1, 2, 1 / numberOfPositions),
-                np.arange(1, 0, -1 / numberOfPositions),
-                np.arange(1, 3, 2 / numberOfPositions),
-            ]
-        ).T
-        # draw start position
-        position = joint_angles[0]
-        robot.forward(position)
-        robot.draw()
-
-        # create slider with update function
-        axSlider: plt.Axes = plt.axes([0.15, 0.06, 0.75, 0.05])
-        self._slider = Slider(axSlider, "progress", 0.0, 1.0, valinit=0)
-
-        def update(_):
-            position_index = int(self._slider.val * (numberOfPositions - 1))
-            position = joint_angles[position_index]
-            robot.forward(position)
-            robot.draw()
-
-        self._slider.on_changed(update)
 
         plt.show()
 

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 import numpy as np
 from matplotlib import pyplot as plt
+from matplotlib.widgets import Slider
 
 from visual_kinematics.RobotSerial import RobotSerial
 from visual_kinematics.Tool import Tool
@@ -28,40 +29,72 @@ class TestRobotSerial(TestCase):
         [0, 0, 0, 1]
     ])
 
-    robot_with_tool = RobotSerial(
-        dh_params=dh_params,
-        dh_type="normal",
-        tool=Tool(t_4_4),
-        ws_lim=None
-    )
-    robot_no_tool = RobotSerial(
-        dh_params=dh_params,
-        dh_type="normal",
-        ws_lim=None
-    )
-    robot_specify_plot_size = RobotSerial(
-        dh_params=dh_params,
-        dh_type="normal",
-        plot_xlim=[-200, 150],
-        plot_ylim=[-500, 500],
-        plot_zlim=[0, 500],
-        ws_lim=None
-    )
-
     def test_draw(self):
+        robot_with_tool = RobotSerial(
+            dh_params=self.dh_params,
+            dh_type="normal",
+            tool=Tool(self.t_4_4),
+            ws_lim=None
+        )
+        robot_no_tool = RobotSerial(
+            dh_params=self.dh_params,
+            dh_type="normal",
+            ws_lim=None
+        )
+        robot_specify_plot_size = RobotSerial(
+            dh_params=self.dh_params,
+            dh_type="normal",
+            plot_xlim=[-200, 150],
+            plot_ylim=[-500, 500],
+            plot_zlim=[0, 500],
+            ws_lim=None
+        )
         joint_angles = np.array([1, -2, 2, 1, 1, 1])
 
         with self.subTest('without tool'):
-            self.robot_no_tool.forward(joint_angles)
-            self.robot_no_tool.draw()
+            robot_no_tool.forward(joint_angles)
+            robot_no_tool.draw()
 
         with self.subTest('with tool'):
-            self.robot_with_tool.forward(joint_angles)
-            self.robot_with_tool.draw()
+            robot_with_tool.forward(joint_angles)
+            robot_with_tool.draw()
 
         with self.subTest('plot size specified (distorted), remove cylinders and orientation markers'):
-            self.robot_specify_plot_size.forward(joint_angles)
-            self.robot_specify_plot_size.draw(cylinder_relative_size=0, orientation_relative_size=0)
+            robot_specify_plot_size.forward(joint_angles)
+            robot_specify_plot_size.draw(cylinder_relative_size=0, orientation_relative_size=0)
+
+        plt.show()
+
+    def test_draw_with_slider(self):
+        robot = RobotSerial(
+            dh_params=self.dh_params,
+            dh_type="normal",
+            tool=Tool(self.t_4_4),
+            ws_lim=None
+        )
+        numberOfPositions = 100
+        joint_angles = np.array([np.arange(1, 2, 1/numberOfPositions),
+                                  np.arange(-2, 0, 2/numberOfPositions),
+                                  np.arange(2, 1, -1/numberOfPositions),
+                                  np.arange(1, 2, 1/numberOfPositions),
+                                  np.arange(1, 0, -1/numberOfPositions),
+                                  np.arange(1, 3, 2/numberOfPositions)]).T
+        # draw start position
+        position = joint_angles[0]
+        robot.forward(position)
+        robot.draw()
+
+        # create slider with update function
+        axSlider: plt.Axes = plt.axes([0.15, 0.06, 0.75, 0.05])
+        self._slider = Slider(axSlider, "progress", 0.0, 1.0, valinit=0)
+
+        def update(_):
+            position_index = int(self._slider.val * (numberOfPositions - 1))
+            position = joint_angles[position_index]
+            robot.forward(position)
+            robot.draw()
+
+        self._slider.on_changed(update)
 
         plt.show()
 
@@ -69,15 +102,26 @@ class TestRobotSerial(TestCase):
         joint_angles_exp = np.array([1, -2, 2, 1, 1, 1])
 
         with self.subTest('without tool'):
-            end_frame = self.robot_no_tool.forward(joint_angles_exp)
-            joint_angles = self.robot_no_tool.inverse(end_frame)
+            robot_no_tool = RobotSerial(
+                dh_params=self.dh_params,
+                dh_type="normal",
+                ws_lim=None
+            )
+            end_frame = robot_no_tool.forward(joint_angles_exp)
+            joint_angles = robot_no_tool.inverse(end_frame)
             [self.assertAlmostEqual(joint_angle, joint_angle_exp)
              for joint_angle, joint_angle_exp
              in zip(joint_angles, joint_angles_exp)]
 
         with self.subTest('with tool'):
-            end_frame = self.robot_with_tool.forward(joint_angles_exp)
-            joint_angles = self.robot_with_tool.inverse(end_frame)
+            robot_with_tool = RobotSerial(
+                dh_params=self.dh_params,
+                dh_type="normal",
+                tool=Tool(self.t_4_4),
+                ws_lim=None
+            )
+            end_frame = robot_with_tool.forward(joint_angles_exp)
+            joint_angles = robot_with_tool.inverse(end_frame)
             [self.assertAlmostEqual(joint_angle, joint_angle_exp)
              for joint_angle, joint_angle_exp
              in zip(joint_angles, joint_angles_exp)]

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -18,8 +18,7 @@ class TestRobotSerial(TestCase):
             [82.3, 0.0, 0.0, 0.0],
         ]
     )
-    # tool
-    # rotate from [0, 0, 1] to [1, 1, 1], translate 1 on y, 2 on z
+    # tool - rotate from [0, 0, 1] to [1, 1, 1], translate 1 on y, 2 on z
     sqrt_3_inv = 1 / np.sqrt(3)
     t_4_4 = np.array([
         [0.5 + 0.5 * sqrt_3_inv, -0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0],
@@ -28,22 +27,15 @@ class TestRobotSerial(TestCase):
         [0, 0, 0, 1]
     ])
 
-    plot_limit = 1.1 * np.sum(np.absolute(dh_params[:, 1]))
     robot_with_tool = RobotSerial(
         dh_params=dh_params,
         dh_type="normal",
         tool=Tool(t_4_4),
-        # plot_xlim=[-plot_limit, plot_limit],
-        # plot_ylim=[-plot_limit, plot_limit],
-        # plot_zlim=[0, plot_limit],
         ws_lim=None
     )
     robot_no_tool = RobotSerial(
         dh_params=dh_params,
         dh_type="normal",
-        # plot_xlim=[-plot_limit, plot_limit],
-        # plot_ylim=[-plot_limit, plot_limit],
-        # plot_zlim=[0, plot_limit],
         ws_lim=None
     )
 

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -41,7 +41,7 @@ class TestRobotSerial(TestCase):
     )
 
     def test_draw(self):
-        joint_angles = np.array([1, 1, 1, 1, 1, 1])
+        joint_angles = np.array([1, -2, 2, 1, 1, 1])
 
         with self.subTest('without tool'):
             self.robot_no_tool.forward(joint_angles)
@@ -54,7 +54,7 @@ class TestRobotSerial(TestCase):
         plt.show()
 
     def test_inverse_numerical(self):
-        joint_angles_exp = np.array([1, 1, 1, 1, 1, 1])
+        joint_angles_exp = np.array([1, -2, 2, 1, 1, 1])
 
         with self.subTest('without tool'):
             end_frame = self.robot_no_tool.forward(joint_angles_exp)

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -1,3 +1,4 @@
+from copy import copy
 from unittest import TestCase
 
 import numpy as np
@@ -32,36 +33,43 @@ class TestRobotSerial(TestCase):
     )
 
     def test_draw(self):
-        robot_with_tool = RobotSerial(
-            dh_params=self.dh_params,
-            dh_type="normal",
-            tool=Tool(self.t_4_4),
-            ws_lim=None,
-        )
-        robot_no_tool = RobotSerial(
-            dh_params=self.dh_params, dh_type="normal", ws_lim=None
-        )
-        robot_specify_plot_size = RobotSerial(
-            dh_params=self.dh_params,
-            dh_type="normal",
-            plot_xlim=[-200, 150],
-            plot_ylim=[-500, 500],
-            plot_zlim=[0, 500],
-            ws_lim=None,
-        )
         joint_angles = np.array([1, -2, 2, 1, 1, 1])
 
         with self.subTest("without tool"):
+            dh_in_mm = copy(self.dh_params)
+            dh_in_mm[:, :2] = 0.001 * dh_in_mm[:, :2]
+            robot_no_tool = RobotSerial(
+                dh_params=dh_in_mm,
+                dh_type="normal",
+                ws_lim=None,
+            )
             robot_no_tool.forward(joint_angles)
             robot_no_tool.draw()
 
         with self.subTest("with tool"):
+            robot_with_tool = RobotSerial(
+                dh_params=self.dh_params,
+                dh_type="normal",
+                tool=Tool(self.t_4_4),
+                plot_xlim=None,
+                plot_ylim=None,
+                plot_zlim=None,
+                ws_lim=None,
+            )
             robot_with_tool.forward(joint_angles)
             robot_with_tool.draw()
 
         with self.subTest(
             "plot size specified (distorted), remove cylinders and orientation markers"
         ):
+            robot_specify_plot_size = RobotSerial(
+                dh_params=self.dh_params,
+                dh_type="normal",
+                plot_xlim=(-200, 150),
+                plot_ylim=(-1000, 1000),
+                plot_zlim=(0, 500),
+                ws_lim=None,
+            )
             robot_specify_plot_size.forward(joint_angles)
             robot_specify_plot_size.draw(
                 cylinder_relative_size=0, orientation_relative_size=0
@@ -74,6 +82,9 @@ class TestRobotSerial(TestCase):
             dh_params=self.dh_params,
             dh_type="normal",
             tool=Tool(self.t_4_4),
+            plot_xlim=None,
+            plot_ylim=None,
+            plot_zlim=None,
             ws_lim=None,
         )
         numberOfPositions = 100
@@ -111,7 +122,9 @@ class TestRobotSerial(TestCase):
 
         with self.subTest("without tool"):
             robot_no_tool = RobotSerial(
-                dh_params=self.dh_params, dh_type="normal", ws_lim=None
+                dh_params=self.dh_params,
+                dh_type="normal",
+                ws_lim=None,
             )
             end_frame = robot_no_tool.forward(joint_angles_exp)
             joint_angles = robot_no_tool.inverse(end_frame)

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -18,15 +18,13 @@ class TestRobotSerial(TestCase):
             [82.3, 0.0, 0.0, 0.0],
         ]
     )
-    dh_params[:, 0] = 1e-3 * dh_params[:, 0]
-    dh_params[:, 1] = 1e-3 * dh_params[:, 1]
     # tool
     # rotate from [0, 0, 1] to [1, 1, 1], translate 1 on y, 2 on z
     sqrt_3_inv = 1 / np.sqrt(3)
     t_4_4 = np.array([
         [0.5 + 0.5 * sqrt_3_inv, -0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0],
-        [-0.5 + 0.5 * sqrt_3_inv, 0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0.050],
-        [-sqrt_3_inv, -sqrt_3_inv, sqrt_3_inv, 0.100],
+        [-0.5 + 0.5 * sqrt_3_inv, 0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 50],
+        [-sqrt_3_inv, -sqrt_3_inv, sqrt_3_inv, 100],
         [0, 0, 0, 1]
     ])
 

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -50,7 +50,7 @@ class TestRobotSerial(TestCase):
             self.robot_with_tool.forward(joint_angles)
             self.robot_with_tool.draw()
 
-    def test_inverse(self):
+    def test_inverse_numerical(self):
         joint_angles_exp = np.array([1, 1, 1, 1, 1, 1])
 
         with self.subTest('without tool'):

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 import numpy as np
+from matplotlib import pyplot as plt
 
 from visual_kinematics.RobotSerial import RobotSerial
 from visual_kinematics.Tool import Tool
@@ -44,11 +45,13 @@ class TestRobotSerial(TestCase):
 
         with self.subTest('without tool'):
             self.robot_no_tool.forward(joint_angles)
-            self.robot_no_tool.show()
+            self.robot_no_tool.draw()
 
         with self.subTest('with tool'):
             self.robot_with_tool.forward(joint_angles)
             self.robot_with_tool.draw()
+
+        plt.show()
 
     def test_inverse_numerical(self):
         joint_angles_exp = np.array([1, 1, 1, 1, 1, 1])

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -39,6 +39,14 @@ class TestRobotSerial(TestCase):
         dh_type="normal",
         ws_lim=None
     )
+    robot_specify_plot_size = RobotSerial(
+        dh_params=dh_params,
+        dh_type="normal",
+        plot_xlim=[-200, 150],
+        plot_ylim=[-500, 500],
+        plot_zlim=[0, 500],
+        ws_lim=None
+    )
 
     def test_draw(self):
         joint_angles = np.array([1, -2, 2, 1, 1, 1])
@@ -50,6 +58,10 @@ class TestRobotSerial(TestCase):
         with self.subTest('with tool'):
             self.robot_with_tool.forward(joint_angles)
             self.robot_with_tool.draw()
+
+        with self.subTest('plot size specified (distorted)'):
+            self.robot_specify_plot_size.forward(joint_angles)
+            self.robot_specify_plot_size.draw()
 
         plt.show()
 

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -1,0 +1,58 @@
+from unittest import TestCase
+
+import numpy as np
+
+from visual_kinematics.RobotSerial import RobotSerial
+from visual_kinematics.Tool import Tool
+
+
+class TestRobotSerial(TestCase):
+    # robot dh parameters
+    dh_params = np.array(
+        [
+            [89.159, 0.0, np.pi / 2, 0.0],
+            [0.0, -425.0, 0.0, 0.0],
+            [0.0, -392.25, 0.0, 0.0],
+            [109.15, 0.0, np.pi / 2, 0.0],
+            [94.65, 0.0, -np.pi / 2, 0.0],
+            [82.3, 0.0, 0.0, 0.0],
+        ]
+    )
+    dh_params[:, 0] = 1e-3 * dh_params[:, 0]
+    dh_params[:, 1] = 1e-3 * dh_params[:, 1]
+    # tool
+    # rotate from [0, 0, 1] to [1, 1, 1], translate 1 on y, 2 on z
+    sqrt_3_inv = 1 / np.sqrt(3)
+    t_4_4 = np.array([
+        [0.5 + 0.5 * sqrt_3_inv, -0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0],
+        [-0.5 + 0.5 * sqrt_3_inv, 0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0.050],
+        [-sqrt_3_inv, -sqrt_3_inv, sqrt_3_inv, 0.100],
+        [0, 0, 0, 1]
+    ])
+
+    plot_limit = 1.1 * np.sum(np.absolute(dh_params[:, 1]))
+    robot_with_tool = RobotSerial(
+        dh_params=dh_params,
+        dh_type="normal",
+        tool=Tool(t_4_4),
+        # plot_xlim=[-plot_limit, plot_limit],
+        # plot_ylim=[-plot_limit, plot_limit],
+        # plot_zlim=[0, plot_limit],
+        ws_lim=None
+    )
+    robot_no_tool = RobotSerial(
+        dh_params=dh_params,
+        dh_type="normal",
+        # plot_xlim=[-plot_limit, plot_limit],
+        # plot_ylim=[-plot_limit, plot_limit],
+        # plot_zlim=[0, plot_limit],
+        ws_lim=None
+    )
+
+    def test_draw(self):
+        joint_angles = np.array([1, 1, 1, 1, 1, 1])
+        self.robot_with_tool.forward(joint_angles)
+        self.robot_with_tool.draw()
+
+        self.robot_no_tool.forward(joint_angles)
+        self.robot_no_tool.show()

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -22,24 +22,24 @@ class TestRobotSerial(TestCase):
     )
     # tool - rotate from [0, 0, 1] to [1, 1, 1], translate 1 on y, 2 on z
     sqrt_3_inv = 1 / np.sqrt(3)
-    t_4_4 = np.array([
-        [0.5 + 0.5 * sqrt_3_inv, -0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0],
-        [-0.5 + 0.5 * sqrt_3_inv, 0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 50],
-        [-sqrt_3_inv, -sqrt_3_inv, sqrt_3_inv, 100],
-        [0, 0, 0, 1]
-    ])
+    t_4_4 = np.array(
+        [
+            [0.5 + 0.5 * sqrt_3_inv, -0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0],
+            [-0.5 + 0.5 * sqrt_3_inv, 0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 50],
+            [-sqrt_3_inv, -sqrt_3_inv, sqrt_3_inv, 100],
+            [0, 0, 0, 1],
+        ]
+    )
 
     def test_draw(self):
         robot_with_tool = RobotSerial(
             dh_params=self.dh_params,
             dh_type="normal",
             tool=Tool(self.t_4_4),
-            ws_lim=None
+            ws_lim=None,
         )
         robot_no_tool = RobotSerial(
-            dh_params=self.dh_params,
-            dh_type="normal",
-            ws_lim=None
+            dh_params=self.dh_params, dh_type="normal", ws_lim=None
         )
         robot_specify_plot_size = RobotSerial(
             dh_params=self.dh_params,
@@ -47,21 +47,25 @@ class TestRobotSerial(TestCase):
             plot_xlim=[-200, 150],
             plot_ylim=[-500, 500],
             plot_zlim=[0, 500],
-            ws_lim=None
+            ws_lim=None,
         )
         joint_angles = np.array([1, -2, 2, 1, 1, 1])
 
-        with self.subTest('without tool'):
+        with self.subTest("without tool"):
             robot_no_tool.forward(joint_angles)
             robot_no_tool.draw()
 
-        with self.subTest('with tool'):
+        with self.subTest("with tool"):
             robot_with_tool.forward(joint_angles)
             robot_with_tool.draw()
 
-        with self.subTest('plot size specified (distorted), remove cylinders and orientation markers'):
+        with self.subTest(
+            "plot size specified (distorted), remove cylinders and orientation markers"
+        ):
             robot_specify_plot_size.forward(joint_angles)
-            robot_specify_plot_size.draw(cylinder_relative_size=0, orientation_relative_size=0)
+            robot_specify_plot_size.draw(
+                cylinder_relative_size=0, orientation_relative_size=0
+            )
 
         plt.show()
 
@@ -70,15 +74,19 @@ class TestRobotSerial(TestCase):
             dh_params=self.dh_params,
             dh_type="normal",
             tool=Tool(self.t_4_4),
-            ws_lim=None
+            ws_lim=None,
         )
         numberOfPositions = 100
-        joint_angles = np.array([np.arange(1, 2, 1/numberOfPositions),
-                                  np.arange(-2, 0, 2/numberOfPositions),
-                                  np.arange(2, 1, -1/numberOfPositions),
-                                  np.arange(1, 2, 1/numberOfPositions),
-                                  np.arange(1, 0, -1/numberOfPositions),
-                                  np.arange(1, 3, 2/numberOfPositions)]).T
+        joint_angles = np.array(
+            [
+                np.arange(1, 2, 1 / numberOfPositions),
+                np.arange(-2, 0, 2 / numberOfPositions),
+                np.arange(2, 1, -1 / numberOfPositions),
+                np.arange(1, 2, 1 / numberOfPositions),
+                np.arange(1, 0, -1 / numberOfPositions),
+                np.arange(1, 3, 2 / numberOfPositions),
+            ]
+        ).T
         # draw start position
         position = joint_angles[0]
         robot.forward(position)
@@ -101,28 +109,27 @@ class TestRobotSerial(TestCase):
     def test_inverse_numerical(self):
         joint_angles_exp = np.array([1, -2, 2, 1, 1, 1])
 
-        with self.subTest('without tool'):
+        with self.subTest("without tool"):
             robot_no_tool = RobotSerial(
-                dh_params=self.dh_params,
-                dh_type="normal",
-                ws_lim=None
+                dh_params=self.dh_params, dh_type="normal", ws_lim=None
             )
             end_frame = robot_no_tool.forward(joint_angles_exp)
             joint_angles = robot_no_tool.inverse(end_frame)
-            [self.assertAlmostEqual(joint_angle, joint_angle_exp)
-             for joint_angle, joint_angle_exp
-             in zip(joint_angles, joint_angles_exp)]
+            [
+                self.assertAlmostEqual(joint_angle, joint_angle_exp)
+                for joint_angle, joint_angle_exp in zip(joint_angles, joint_angles_exp)
+            ]
 
-        with self.subTest('with tool'):
+        with self.subTest("with tool"):
             robot_with_tool = RobotSerial(
                 dh_params=self.dh_params,
                 dh_type="normal",
                 tool=Tool(self.t_4_4),
-                ws_lim=None
+                ws_lim=None,
             )
             end_frame = robot_with_tool.forward(joint_angles_exp)
             joint_angles = robot_with_tool.inverse(end_frame)
-            [self.assertAlmostEqual(joint_angle, joint_angle_exp)
-             for joint_angle, joint_angle_exp
-             in zip(joint_angles, joint_angles_exp)]
-
+            [
+                self.assertAlmostEqual(joint_angle, joint_angle_exp)
+                for joint_angle, joint_angle_exp in zip(joint_angles, joint_angles_exp)
+            ]

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -8,7 +8,7 @@ from visual_kinematics.Tool import Tool
 
 
 class TestRobotSerial(TestCase):
-    # robot dh parameters
+    # robot dh parameters (ur5, in mm)
     dh_params = np.array(
         [
             [89.159, 0.0, np.pi / 2, 0.0],
@@ -59,10 +59,14 @@ class TestRobotSerial(TestCase):
         with self.subTest('without tool'):
             end_frame = self.robot_no_tool.forward(joint_angles_exp)
             joint_angles = self.robot_no_tool.inverse(end_frame)
-            [self.assertAlmostEqual(joint_angle, joint_angle_exp) for joint_angle, joint_angle_exp in zip(joint_angles, joint_angles_exp)]
+            [self.assertAlmostEqual(joint_angle, joint_angle_exp)
+             for joint_angle, joint_angle_exp
+             in zip(joint_angles, joint_angles_exp)]
 
         with self.subTest('with tool'):
             end_frame = self.robot_with_tool.forward(joint_angles_exp)
             joint_angles = self.robot_with_tool.inverse(end_frame)
-            [self.assertAlmostEqual(joint_angle, joint_angle_exp) for joint_angle, joint_angle_exp in zip(joint_angles, joint_angles_exp)]
+            [self.assertAlmostEqual(joint_angle, joint_angle_exp)
+             for joint_angle, joint_angle_exp
+             in zip(joint_angles, joint_angles_exp)]
 

--- a/tests/test_RobotSerial.py
+++ b/tests/test_RobotSerial.py
@@ -31,50 +31,6 @@ class TestRobotSerial(TestCase):
         ]
     )
 
-    def test_draw(self):
-        joint_angles = np.array([1, -2, 2, 1, 1, 1])
-
-        with self.subTest("without tool"):
-            # convert to m so it fits in the default plot window
-            dh_in_m = copy(self.dh_params)
-            dh_in_m[:, :2] = 0.001 * dh_in_m[:, :2]
-            robot_no_tool = RobotSerial(
-                dh_params=dh_in_m,
-                dh_type="normal",
-                ws_lim=None,
-            )
-            robot_no_tool.forward(joint_angles)
-            robot_no_tool.draw()
-
-        with self.subTest("with tool, use auto zoom"):
-            robot_with_tool = RobotSerial(
-                dh_params=self.dh_params,
-                dh_type="normal",
-                tool=Tool(self.t_4_4),
-                plot_xlim=None,
-                plot_ylim=None,
-                plot_zlim=None,
-                ws_lim=None,
-            )
-            robot_with_tool.forward(joint_angles)
-            robot_with_tool.draw()
-
-        with self.subTest("plot size specified (distorted), remove cylinders and orientation markers"):
-            robot_specify_plot_size = RobotSerial(
-                dh_params=self.dh_params,
-                dh_type="normal",
-                plot_xlim=(-200, 150),
-                plot_ylim=(-1000, 1000),
-                plot_zlim=(0, 500),
-                ws_lim=None,
-            )
-            robot_specify_plot_size.forward(joint_angles)
-            robot_specify_plot_size.draw(
-                cylinder_relative_size=0, orientation_relative_size=0
-            )
-
-        plt.show()
-
     def test_inverse_numerical(self):
         joint_angles_exp = np.array([1, -2, 2, 1, 1, 1])
 

--- a/tests/test_Tool.py
+++ b/tests/test_Tool.py
@@ -11,21 +11,22 @@ class TestTool(TestCase):
     def test_init(self):
         # rotate from [0, 0, 1] to [1, 1, 1], translate 1 on y, 2 on z
         sqrt_3_inv = 1 / np.sqrt(3)
-        t_4_4 = np.array([
-            [0.5 + 0.5 * sqrt_3_inv, -0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0],
-            [-0.5 + 0.5 * sqrt_3_inv, 0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 1],
-            [-sqrt_3_inv, -sqrt_3_inv, sqrt_3_inv, 2],
-            [0, 0, 0, 1]
-        ])
-        tool = Tool(t_4_4=t_4_4, name='test_tool')
+        t_4_4 = np.array(
+            [
+                [0.5 + 0.5 * sqrt_3_inv, -0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0],
+                [-0.5 + 0.5 * sqrt_3_inv, 0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 1],
+                [-sqrt_3_inv, -sqrt_3_inv, sqrt_3_inv, 2],
+                [0, 0, 0, 1],
+            ]
+        )
+        tool = Tool(t_4_4=t_4_4, name="test_tool")
 
-        with self.subTest('assert that tool is derived from frame'):
+        with self.subTest("assert that tool is derived from frame"):
             self.assertIsInstance(tool, Frame)
 
-        with self.subTest('assert that tool rotation is right'):
+        with self.subTest("assert that tool rotation is right"):
             tool_rotation = Rotation.from_matrix(tool.r_3_3)
             tool_rot_vec = tool_rotation.as_rotvec()
             self.assertEqual(-tool_rot_vec[0], tool_rot_vec[1])
             self.assertEqual(tool_rot_vec[2], 0)
             self.assertAlmostEqual(np.linalg.norm(tool_rot_vec), 0.9553166197423132)
-

--- a/tests/test_Tool.py
+++ b/tests/test_Tool.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from visual_kinematics import Frame
+from visual_kinematics.Tool import Tool
+
+
+class TestTool(TestCase):
+    def test_init(self):
+        # rotate from [0, 0, 1] to [1, 1, 1], translate 1 on y, 2 on z
+        sqrt_3_inv = 1 / np.sqrt(3)
+        t_4_4 = np.array([
+            [0.5 + 0.5 * sqrt_3_inv, -0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 0],
+            [-0.5 + 0.5 * sqrt_3_inv, 0.5 + 0.5 * sqrt_3_inv, sqrt_3_inv, 1],
+            [-sqrt_3_inv, -sqrt_3_inv, sqrt_3_inv, 2],
+            [0, 0, 0, 1]
+        ])
+        tool = Tool(t_4_4=t_4_4, name='test_tool')
+
+        with self.subTest('assert that tool is derived from frame'):
+            self.assertIsInstance(tool, Frame)
+
+        with self.subTest('assert that tool rotation is right'):
+            tool_rotation = Rotation.from_matrix(tool.r_3_3)
+            tool_rot_vec = tool_rotation.as_rotvec()
+            self.assertEqual(-tool_rot_vec[0], tool_rot_vec[1])
+            self.assertEqual(tool_rot_vec[2], 0)
+            self.assertAlmostEqual(np.linalg.norm(tool_rot_vec), 0.9553166197423132)
+

--- a/visual_kinematics/Frame.py
+++ b/visual_kinematics/Frame.py
@@ -1,6 +1,8 @@
+from math import cos as c
+from math import sin as s
+
 import numpy as np
 from scipy.spatial.transform import Rotation
-from math import sin as s, cos as c
 
 
 class Frame:

--- a/visual_kinematics/Robot.py
+++ b/visual_kinematics/Robot.py
@@ -85,6 +85,8 @@ class Robot(object):
             self.ax.set_ylim(self.plot_ylim)
         if self.plot_zlim is not None:
             self.ax.set_zlim(self.plot_zlim)
+        if self.plot_xlim is None and self.plot_ylim is None and self.plot_zlim is None:
+            self.set_aspect_equal_3d()
         self.ax.set_xlabel("x")
         self.ax.set_ylabel("y")
         self.ax.set_zlabel("z")
@@ -104,3 +106,22 @@ class Robot(object):
         if ws:
             self.draw_ws()
         plt.show()
+
+    def set_aspect_equal_3d(self):
+        """Fix equal aspect bug for 3D plots."""
+
+        x_lim = self.ax.get_xlim3d()
+        y_lim = self.ax.get_ylim3d()
+        z_lim = self.ax.get_zlim3d()
+
+        x_mean = np.mean(x_lim)
+        y_mean = np.mean(y_lim)
+        z_mean = np.mean(z_lim)
+
+        plot_radius = max(
+            [abs(lim - mean) for lims, mean in ((x_lim, x_mean), (y_lim, y_mean), (z_lim, z_mean)) for lim in lims]
+        )
+
+        self.ax.set_xlim3d([x_mean - plot_radius, x_mean + plot_radius])
+        self.ax.set_ylim3d([y_mean - plot_radius, y_mean + plot_radius])
+        self.ax.set_zlim3d([z_mean - plot_radius, z_mean + plot_radius])

--- a/visual_kinematics/Robot.py
+++ b/visual_kinematics/Robot.py
@@ -1,6 +1,7 @@
-import numpy as np
 from abc import abstractmethod
+
 import matplotlib.pyplot as plt
+import numpy as np
 
 
 class Robot(object):

--- a/visual_kinematics/Robot.py
+++ b/visual_kinematics/Robot.py
@@ -11,8 +11,8 @@ class Robot(object):
     # ws_lim: lower and upper bound of all axes [num_axis, 2]
     # ws_division: number of sample points of all axes
     # ==================
-    def __init__(self, params, initial_offset, tool=None, plot_xlim=None, plot_ylim=None,
-                 plot_zlim=None, ws_lim=None, ws_division=5):
+    def __init__(self, params, initial_offset, tool=None, plot_xlim=(-0.5, 0.5), plot_ylim=(-0.5, 0.5),
+                 plot_zlim=(0, 1), ws_lim=None, ws_division=5):
         self.params = params
         self.initial_offset = initial_offset
         self.axis_values = np.zeros(initial_offset.shape, dtype=np.float64)

--- a/visual_kinematics/Robot.py
+++ b/visual_kinematics/Robot.py
@@ -1,5 +1,4 @@
-from visual_kinematics.Frame import *
-from numpy import pi
+import numpy as np
 from abc import abstractmethod
 import matplotlib.pyplot as plt
 
@@ -11,11 +10,12 @@ class Robot(object):
     # ws_lim: lower and upper bound of all axes [num_axis, 2]
     # ws_division: number of sample points of all axes
     # ==================
-    def __init__(self, params, initial_offset, plot_xlim=[-0.5, 0.5], plot_ylim=[-0.5, 0.5], plot_zlim=[0.0, 1.0],
-                 ws_lim=None, ws_division=5):
+    def __init__(self, params, initial_offset, tool=None, plot_xlim=None, plot_ylim=None,
+                 plot_zlim=None, ws_lim=None, ws_division=5):
         self.params = params
         self.initial_offset = initial_offset
         self.axis_values = np.zeros(initial_offset.shape, dtype=np.float64)
+        self.tool = tool
         # is_reachable_inverse must be set everytime when inverse kinematics is performed
         self.is_reachable_inverse = True
         # plot related
@@ -26,7 +26,7 @@ class Robot(object):
         self.ax = self.figure.add_subplot(111, projection="3d")
         # workspace related
         if ws_lim is None:
-            self.ws_lim = np.array([[-pi, pi]]*self.num_axis)
+            self.ws_lim = np.array([[-np.pi, np.pi]]*self.num_axis)
         else:
             self.ws_lim = ws_lim
         self.ws_division = ws_division
@@ -79,9 +79,12 @@ class Robot(object):
     # ================== plot related
     # ==================
     def plot_settings(self):
-        self.ax.set_xlim(self.plot_xlim)
-        self.ax.set_ylim(self.plot_ylim)
-        self.ax.set_zlim(self.plot_zlim)
+        if self.plot_xlim is not None:
+            self.ax.set_xlim(self.plot_xlim)
+        if self.plot_ylim is not None:
+            self.ax.set_ylim(self.plot_ylim)
+        if self.plot_zlim is not None:
+            self.ax.set_zlim(self.plot_zlim)
         self.ax.set_xlabel("x")
         self.ax.set_ylabel("y")
         self.ax.set_zlabel("z")

--- a/visual_kinematics/Robot.py
+++ b/visual_kinematics/Robot.py
@@ -19,7 +19,7 @@ class Robot(object):
         self.tool = tool
         # is_reachable_inverse must be set everytime when inverse kinematics is performed
         self.is_reachable_inverse = True
-        # plot related
+        # plot related: if you specify lim values autozoom will be deactivated
         self.plot_xlim = plot_xlim
         self.plot_ylim = plot_ylim
         self.plot_zlim = plot_zlim

--- a/visual_kinematics/Robot.py
+++ b/visual_kinematics/Robot.py
@@ -92,6 +92,10 @@ class Robot(object):
         self.ax.set_ylabel("y")
         self.ax.set_zlabel("z")
 
+        plot_size = max(np.diff(self.ax.get_xlim3d()), np.diff(self.ax.get_ylim3d()), np.diff(self.ax.get_zlim3d()))[0]
+
+        return plot_size
+
     @abstractmethod
     def draw(self):
         pass

--- a/visual_kinematics/RobotDelta.py
+++ b/visual_kinematics/RobotDelta.py
@@ -7,9 +7,10 @@ import logging
 
 class RobotDelta(Robot):
     # params [4, ] [r1, r2, l1, l2]
-    def __init__(self, params, plot_xlim=[-0.5, 0.5], plot_ylim=[-0.5, 0.5], plot_zlim=[-1.0, 0.0],
+    def __init__(self, params, plot_xlim=None, plot_ylim=None, plot_zlim=None,
                  ws_lim=None, ws_division=5):
-        Robot.__init__(self, params, np.zeros([3, ]), plot_xlim, plot_ylim, plot_zlim, ws_lim, ws_division)
+        Robot.__init__(self, params, np.zeros([3, ]), plot_xlim=plot_xlim, plot_ylim=plot_ylim, plot_zlim=plot_zlim,
+                       ws_lim=ws_lim, ws_division=ws_division)
         self.is_reachable_forward = True
 
     # ================== Definition of r1, r2, l1, l2

--- a/visual_kinematics/RobotDelta.py
+++ b/visual_kinematics/RobotDelta.py
@@ -1,3 +1,4 @@
+from visual_kinematics import Frame
 from visual_kinematics.Robot import *
 from visual_kinematics.utility import simplify_angle
 from math import pi, atan2, sqrt
@@ -166,7 +167,6 @@ class RobotDelta(Robot):
 
     def draw(self):
         self.ax.clear()
-        self.plot_settings()
         # get point coordinates
         oc = self.oc  # [3, 3]
         ob = oc + self.cb  # [3, 3]
@@ -193,3 +193,5 @@ class RobotDelta(Robot):
         # plot two dots
         self.ax.scatter([0.], [0.], [0.], c="red", marker="o")
         self.ax.scatter(op[0], op[1], op[2], c="red", marker="o")
+
+        self.plot_settings()

--- a/visual_kinematics/RobotDelta.py
+++ b/visual_kinematics/RobotDelta.py
@@ -10,7 +10,7 @@ from visual_kinematics.utility import simplify_angle
 
 class RobotDelta(Robot):
     # params [4, ] [r1, r2, l1, l2]
-    def __init__(self, params, plot_xlim=(-0.5, 0.5), plot_ylim=(-0.5, 0.5), plot_zlim=(0, 1),
+    def __init__(self, params, plot_xlim=(-0.5, 0.5), plot_ylim=(-0.5, 0.5), plot_zlim=(-1, 0),
                  ws_lim=None, ws_division=5):
         Robot.__init__(self, params, np.zeros([3, ]), plot_xlim=plot_xlim, plot_ylim=plot_ylim, plot_zlim=plot_zlim,
                        ws_lim=ws_lim, ws_division=ws_division)

--- a/visual_kinematics/RobotDelta.py
+++ b/visual_kinematics/RobotDelta.py
@@ -1,9 +1,11 @@
-from visual_kinematics import Frame
-from visual_kinematics.Robot import *
-from visual_kinematics.utility import simplify_angle
-from math import pi, atan2, sqrt
-
 import logging
+from math import atan2, pi, sqrt
+
+import numpy as np
+
+from visual_kinematics.Frame import Frame
+from visual_kinematics.Robot import Robot
+from visual_kinematics.utility import simplify_angle
 
 
 class RobotDelta(Robot):

--- a/visual_kinematics/RobotDelta.py
+++ b/visual_kinematics/RobotDelta.py
@@ -10,7 +10,7 @@ from visual_kinematics.utility import simplify_angle
 
 class RobotDelta(Robot):
     # params [4, ] [r1, r2, l1, l2]
-    def __init__(self, params, plot_xlim=None, plot_ylim=None, plot_zlim=None,
+    def __init__(self, params, plot_xlim=(-0.5, 0.5), plot_ylim=(-0.5, 0.5), plot_zlim=(0, 1),
                  ws_lim=None, ws_division=5):
         Robot.__init__(self, params, np.zeros([3, ]), plot_xlim=plot_xlim, plot_ylim=plot_ylim, plot_zlim=plot_zlim,
                        ws_lim=ws_lim, ws_division=ws_division)

--- a/visual_kinematics/RobotSerial.py
+++ b/visual_kinematics/RobotSerial.py
@@ -154,8 +154,8 @@ class RobotSerial(Robot):
         plot_size = self.plot_settings()
 
         # plot axes using cylinders
-        cy_radius = plot_size / 50
-        cy_len = cy_radius * 4.
+        cy_radius = plot_size / 100
+        cy_len = cy_radius * 10.
         cy_div = 11
         theta = np.linspace(0, 2 * np.pi, cy_div)
         cx = np.array([cy_radius * np.cos(theta)])
@@ -167,14 +167,14 @@ class RobotSerial(Robot):
         points[1] = cy.flatten()
         points[2] = cz.flatten()
         self.ax.plot_surface(points[0].reshape(2, cy_div), points[1].reshape(2, cy_div), points[2].reshape(2, cy_div),
-                             color="pink", rstride=1, cstride=1, linewidth=0, alpha=0.4)
+                             color="pink", rstride=1, cstride=1, linewidth=0)
         for i in range(n_lines - 1):
             f = axis_frames[i]
             points_f = f.r_3_3.dot(points) + f.t_3_1
             self.ax.plot_surface(points_f[0].reshape(2, cy_div),
                                  points_f[1].reshape(2, cy_div),
                                  points_f[2].reshape(2, cy_div),
-                                 color="pink", rstride=1, cstride=1, linewidth=0, alpha=0.4)
+                                 color="pink", rstride=1, cstride=1, linewidth=0)
 
         # plot the end frame
         end_pos = axis_frames[-1].t_3_1.flatten()

--- a/visual_kinematics/RobotSerial.py
+++ b/visual_kinematics/RobotSerial.py
@@ -167,14 +167,14 @@ class RobotSerial(Robot):
         points[1] = cy.flatten()
         points[2] = cz.flatten()
         self.ax.plot_surface(points[0].reshape(2, cy_div), points[1].reshape(2, cy_div), points[2].reshape(2, cy_div),
-                             color="pink", rstride=1, cstride=1, linewidth=0)
+                             color="pink", rstride=1, cstride=1, linewidth=0, alpha=0.4)
         for i in range(n_lines - 1):
             f = axis_frames[i]
             points_f = f.r_3_3.dot(points) + f.t_3_1
             self.ax.plot_surface(points_f[0].reshape(2, cy_div),
                                  points_f[1].reshape(2, cy_div),
                                  points_f[2].reshape(2, cy_div),
-                                 color="pink", rstride=1, cstride=1, linewidth=0)
+                                 color="pink", rstride=1, cstride=1, linewidth=0, alpha=0.4)
 
         # plot the end frame
         end_pos = axis_frames[-1].t_3_1.flatten()

--- a/visual_kinematics/RobotSerial.py
+++ b/visual_kinematics/RobotSerial.py
@@ -128,7 +128,6 @@ class RobotSerial(Robot):
 
     def draw(self):
         self.ax.clear()
-        self.plot_settings()
 
         # plot the arm
         x, y, z = [0.], [0.], [0.]
@@ -173,13 +172,12 @@ class RobotSerial(Robot):
         # plot the end frame
         pos = axis_frames[-1].t_3_1.flatten()
         rot = axis_frames[-1].r_3_3
-        scale = 0.2
-        self.ax.plot(np.array([pos[0], pos[0] + scale * rot[0, 0]]),
-                     np.array([pos[1], pos[1] + scale * rot[1, 0]]),
-                     np.array([pos[2], pos[2] + scale * rot[2, 0]]), color="red")
-        self.ax.plot(np.array([pos[0], pos[0] + scale * rot[0, 1]]),
-                     np.array([pos[1], pos[1] + scale * rot[1, 1]]),
-                     np.array([pos[2], pos[2] + scale * rot[2, 1]]), color="green")
-        self.ax.plot(np.array([pos[0], pos[0] + scale * rot[0, 2]]),
-                     np.array([pos[1], pos[1] + scale * rot[1, 2]]),
-                     np.array([pos[2], pos[2] + scale * rot[2, 2]]), color="blue")
+        rotated_x_axis = rot[:, 0]
+        rotated_y_axis = rot[:, 1]
+        rotated_z_axis = rot[:, 2]
+        scale = 0.1
+        self.ax.plot(*np.array([pos, pos + scale * rotated_x_axis]).T.tolist(), color="red")
+        self.ax.plot(*np.array([pos, pos + scale * rotated_y_axis]).T.tolist(), color="green")
+        self.ax.plot(*np.array([pos, pos + scale * rotated_z_axis]).T.tolist(), color="blue")
+
+        self.plot_settings()

--- a/visual_kinematics/RobotSerial.py
+++ b/visual_kinematics/RobotSerial.py
@@ -150,9 +150,10 @@ class RobotSerial(Robot):
             self.ax.scatter(x[-1], y[-1], z[-1], c="orange", marker="o")
 
         # plot axes using cylinders
-        cy_radius = np.amax(self.params[:, 0:2]) * 0.05
+        axes_scale = max(max(np.abs(x)), max(np.abs(y)), max(np.abs(z))) / 5000
+        cy_radius = np.amax(self.params[:, 0:2]) * axes_scale
         cy_len = cy_radius * 4.
-        cy_div = 4 + 1
+        cy_div = 11
         theta = np.linspace(0, 2 * np.pi, cy_div)
         cx = np.array([cy_radius * np.cos(theta)])
         cz = np.array([-0.5 * cy_len, 0.5 * cy_len])
@@ -173,14 +174,14 @@ class RobotSerial(Robot):
                                  color="pink", rstride=1, cstride=1, linewidth=0, alpha=0.4)
 
         # plot the end frame
-        pos = axis_frames[-1].t_3_1.flatten()
-        rot = axis_frames[-1].r_3_3
-        rotated_x_axis = rot[:, 0]
-        rotated_y_axis = rot[:, 1]
-        rotated_z_axis = rot[:, 2]
-        scale = max(np.abs(pos)) / 10
-        self.ax.plot(*np.array([pos, pos + scale * rotated_x_axis]).T.tolist(), color="red")
-        self.ax.plot(*np.array([pos, pos + scale * rotated_y_axis]).T.tolist(), color="green")
-        self.ax.plot(*np.array([pos, pos + scale * rotated_z_axis]).T.tolist(), color="blue")
+        end_pos = axis_frames[-1].t_3_1.flatten()
+        end_rot = axis_frames[-1].r_3_3
+        rotated_x_axis = end_rot[:, 0]
+        rotated_y_axis = end_rot[:, 1]
+        rotated_z_axis = end_rot[:, 2]
+        end_frame_scale = max(np.abs(end_pos)) / 10
+        self.ax.plot(*np.array([end_pos, end_pos + end_frame_scale * rotated_x_axis]).T.tolist(), color="red")
+        self.ax.plot(*np.array([end_pos, end_pos + end_frame_scale * rotated_y_axis]).T.tolist(), color="green")
+        self.ax.plot(*np.array([end_pos, end_pos + end_frame_scale * rotated_z_axis]).T.tolist(), color="blue")
 
         self.plot_settings()

--- a/visual_kinematics/RobotSerial.py
+++ b/visual_kinematics/RobotSerial.py
@@ -175,7 +175,7 @@ class RobotSerial(Robot):
         rotated_x_axis = rot[:, 0]
         rotated_y_axis = rot[:, 1]
         rotated_z_axis = rot[:, 2]
-        scale = 0.1
+        scale = max(np.abs(pos)) / 10
         self.ax.plot(*np.array([pos, pos + scale * rotated_x_axis]).T.tolist(), color="red")
         self.ax.plot(*np.array([pos, pos + scale * rotated_y_axis]).T.tolist(), color="green")
         self.ax.plot(*np.array([pos, pos + scale * rotated_z_axis]).T.tolist(), color="blue")

--- a/visual_kinematics/RobotSerial.py
+++ b/visual_kinematics/RobotSerial.py
@@ -20,8 +20,8 @@ class RobotSerial(Robot):
     # |  x  |  x  |    x    |                  |    x    |
     # | ... | ... |   ...   |                  |   ...   |
     # ==================
-    def __init__(self, dh_params, dh_type="normal", tool=None, analytical_inv=None, plot_xlim=None,
-                 plot_ylim=None, plot_zlim=None, ws_lim=None, ws_division=5, inv_m="jac_pinv",
+    def __init__(self, dh_params, dh_type="normal", tool=None, analytical_inv=None, plot_xlim=(-0.5, 0.5),
+                 plot_ylim=(-0.5, 0.5),  plot_zlim=(0, 1), ws_lim=None, ws_division=5, inv_m="jac_pinv",
                  step_size=5e-1, max_iter=300, final_loss=1e-4):
         super().__init__(params=dh_params[:, 0:3], initial_offset=dh_params[:, 3], tool=tool, plot_xlim=plot_xlim,
                          plot_ylim=plot_ylim, plot_zlim=plot_zlim, ws_lim=ws_lim, ws_division=ws_division)

--- a/visual_kinematics/RobotSerial.py
+++ b/visual_kinematics/RobotSerial.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from visual_kinematics.Robot import *
+from visual_kinematics.Robot import Robot
+from visual_kinematics.Frame import Frame
 from visual_kinematics.utility import simplify_angles
 import logging
 
@@ -18,12 +19,12 @@ class RobotSerial(Robot):
     # |  x  |  x  |    x    |                  |    x    |
     # | ... | ... |   ...   |                  |   ...   |
     # ==================
-    def __init__(self, dh_params, dh_type="normal", analytical_inv=None
-                 , plot_xlim=[-0.5, 0.5], plot_ylim=[-0.5, 0.5], plot_zlim=[0.0, 1.0]
-                 , ws_lim=None, ws_division=5
-                 , inv_m="jac_pinv", step_size=5e-1, max_iter=300, final_loss=1e-4):
-        Robot.__init__(self, dh_params[:, 0:3], dh_params[:, 3], plot_xlim, plot_ylim, plot_zlim, ws_lim, ws_division)
-        self.dh_type = dh_type # can be only normal or modified
+    def __init__(self, dh_params, dh_type="normal", tool=None, analytical_inv=None, plot_xlim=None,
+                 plot_ylim=None, plot_zlim=None, ws_lim=None, ws_division=5, inv_m="jac_pinv",
+                 step_size=5e-1, max_iter=300, final_loss=1e-4):
+        super().__init__(params=dh_params[:, 0:3], initial_offset=dh_params[:, 3], tool=tool, plot_xlim=plot_xlim,
+                         plot_ylim=plot_ylim, plot_zlim=plot_zlim, ws_lim=ws_lim, ws_division=ws_division)
+        self.dh_type = dh_type  # can be only normal or modified
         if dh_type != "normal" and dh_type != "modified":
             raise Exception("dh_type can only be \"normal\" or \"modified\"")
         self.analytical_inv = analytical_inv
@@ -49,6 +50,8 @@ class RobotSerial(Robot):
                 ts.append(Frame.from_dh(dh[i]))
             else:
                 ts.append(Frame.from_dh_modified(dh[i]))
+        if self.tool is not None:
+            ts.append(self.tool)
         return ts
 
     # base to end transformation
@@ -60,6 +63,9 @@ class RobotSerial(Robot):
         for i in range(self.num_axis):
             f = f * ts[i]
             fs.append(f)
+        if self.tool is not None:
+            f = f * self.tool
+            fs.append(f)
         return fs
 
     @property
@@ -69,16 +75,19 @@ class RobotSerial(Robot):
     @property
     def jacobian(self):
         axis_fs = self.axis_frames
-        jac = np.zeros([6, self.num_axis])
+        n_rows = self.num_axis + 1 if self.tool is not None else self.num_axis
+        jac = np.zeros([6, n_rows])
         if self.dh_type == "normal":
             jac[0:3, 0] = np.cross(np.array([0., 0., 1.]), axis_fs[-1].t_3_1.reshape([3, ]))
             jac[3:6, 0] = np.array([0., 0., 1.])
-            for i in range(1, self.num_axis):
-                jac[0:3, i] = np.cross(axis_fs[i-1].z_3_1.reshape([3, ]), (axis_fs[-1].t_3_1 - axis_fs[i-1].t_3_1).reshape([3, ]))
-                jac[3:6, i] = axis_fs[i-1].z_3_1.reshape([3, ])
+            for i in range(1, n_rows):
+                jac[0:3, i] = np.cross(axis_fs[i - 1].z_3_1.reshape([3, ]),
+                                       (axis_fs[-1].t_3_1 - axis_fs[i - 1].t_3_1).reshape([3, ]))
+                jac[3:6, i] = axis_fs[i - 1].z_3_1.reshape([3, ])
         if self.dh_type == "modified":
-            for i in range(0, self.num_axis):
-                jac[0:3, i] = np.cross(axis_fs[i].z_3_1.reshape([3, ]), (axis_fs[-1].t_3_1 - axis_fs[i].t_3_1).reshape([3, ]))
+            for i in range(0, n_rows):
+                jac[0:3, i] = np.cross(axis_fs[i].z_3_1.reshape([3, ]),
+                                       (axis_fs[-1].t_3_1 - axis_fs[i].t_3_1).reshape([3, ]))
                 jac[3:6, i] = axis_fs[i].z_3_1.reshape([3, ])
         return jac
 
@@ -89,6 +98,7 @@ class RobotSerial(Robot):
             return self.inverse_numerical(end_frame)
 
     def inverse_analytical(self, end_frame, method):
+        # TODO give tool to method
         self.is_reachable_inverse, theta_x = method(self.dh_params, end_frame)
         self.forward(theta_x)
         return theta_x
@@ -105,7 +115,8 @@ class RobotSerial(Robot):
             dx[0:3, 0] = (end_frame.t_3_1 - end.t_3_1).reshape([3, ])
             diff = end.inv * end_frame
             dx[3:6, 0] = end.r_3_3.dot(diff.r_3.reshape([3, 1])).reshape([3, ])
-            if np.linalg.norm(dx, ord=2) < self.final_loss or np.linalg.norm(dx - last_dx, ord=2) < 0.1*self.final_loss:
+            if np.linalg.norm(dx, ord=2) < self.final_loss or np.linalg.norm(dx - last_dx,
+                                                                             ord=2) < 0.1 * self.final_loss:
                 self.axis_values = simplify_angles(self.axis_values)
                 self.is_reachable_inverse = True
                 return self.axis_values
@@ -118,15 +129,24 @@ class RobotSerial(Robot):
     def draw(self):
         self.ax.clear()
         self.plot_settings()
+
         # plot the arm
         x, y, z = [0.], [0.], [0.]
         axis_frames = self.axis_frames
-        for i in range(self.num_axis):
+        n_lines = self.num_axis + 1 if self.tool is not None else self.num_axis
+        for i in range(n_lines):
             x.append(axis_frames[i].t_3_1[0, 0])
             y.append(axis_frames[i].t_3_1[1, 0])
             z.append(axis_frames[i].t_3_1[2, 0])
-        self.ax.plot_wireframe(x, y, np.array([z]))
-        self.ax.scatter(x[1:], y[1:], z[1:], c="red", marker="o")
+        if self.tool is None:
+            self.ax.plot_wireframe(x, y, np.array([z]))
+            self.ax.scatter(x[1:], y[1:], z[1:], c="red", marker="o")
+        else:
+            self.ax.plot_wireframe(x[:-1], y[:-1], np.array([z[:-1]]))
+            self.ax.scatter(x[1:-1], y[1:-1], z[1:-1], c="red", marker="o")
+            self.ax.plot_wireframe(x[-2:], y[-2:], np.array([z[-2:]]), color="orange")
+            self.ax.scatter(x[-1], y[-1], z[-1], c="orange", marker="o")
+
         # plot axes using cylinders
         cy_radius = np.amax(self.params[:, 0:2]) * 0.05
         cy_len = cy_radius * 4.
@@ -142,19 +162,24 @@ class RobotSerial(Robot):
         points[2] = cz.flatten()
         self.ax.plot_surface(points[0].reshape(2, cy_div), points[1].reshape(2, cy_div), points[2].reshape(2, cy_div),
                              color="pink", rstride=1, cstride=1, linewidth=0, alpha=0.4)
-        for i in range(self.num_axis-1):
+        for i in range(n_lines - 1):
             f = axis_frames[i]
             points_f = f.r_3_3.dot(points) + f.t_3_1
-            self.ax.plot_surface(points_f[0].reshape(2, cy_div), points_f[1].reshape(2, cy_div), points_f[2].reshape(2, cy_div)
-                                 , color="pink", rstride=1, cstride=1, linewidth=0, alpha=0.4)
+            self.ax.plot_surface(points_f[0].reshape(2, cy_div),
+                                 points_f[1].reshape(2, cy_div),
+                                 points_f[2].reshape(2, cy_div),
+                                 color="pink", rstride=1, cstride=1, linewidth=0, alpha=0.4)
+
         # plot the end frame
-        f = axis_frames[-1].t_4_4
-        self.ax.plot_wireframe(np.array([f[0, 3], f[0, 3] + 0.2 * f[0, 0]]),
-                               np.array([f[1, 3], f[1, 3] + 0.2 * f[1, 0]]),
-                               np.array([[f[2, 3], f[2, 3] + 0.2 * f[2, 0]]]), color="red")
-        self.ax.plot_wireframe(np.array([f[0, 3], f[0, 3] + 0.2 * f[0, 1]]),
-                               np.array([f[1, 3], f[1, 3] + 0.2 * f[1, 1]]),
-                               np.array([[f[2, 3], f[2, 3] + 0.2 * f[2, 1]]]), color="green")
-        self.ax.plot_wireframe(np.array([f[0, 3], f[0, 3] + 0.2 * f[0, 2]]),
-                               np.array([f[1, 3], f[1, 3] + 0.2 * f[1, 2]]),
-                               np.array([[f[2, 3], f[2, 3] + 0.2 * f[2, 2]]]), color="blue")
+        pos = axis_frames[-1].t_3_1.flatten()
+        rot = axis_frames[-1].r_3_3
+        scale = 0.2
+        self.ax.plot(np.array([pos[0], pos[0] + scale * rot[0, 0]]),
+                     np.array([pos[1], pos[1] + scale * rot[1, 0]]),
+                     np.array([pos[2], pos[2] + scale * rot[2, 0]]), color="red")
+        self.ax.plot(np.array([pos[0], pos[0] + scale * rot[0, 1]]),
+                     np.array([pos[1], pos[1] + scale * rot[1, 1]]),
+                     np.array([pos[2], pos[2] + scale * rot[2, 1]]), color="green")
+        self.ax.plot(np.array([pos[0], pos[0] + scale * rot[0, 2]]),
+                     np.array([pos[1], pos[1] + scale * rot[1, 2]]),
+                     np.array([pos[2], pos[2] + scale * rot[2, 2]]), color="blue")

--- a/visual_kinematics/RobotSerial.py
+++ b/visual_kinematics/RobotSerial.py
@@ -130,7 +130,7 @@ class RobotSerial(Robot):
         logging.error("Pose cannot be reached!")
         self.is_reachable_inverse = False
 
-    def draw(self):
+    def draw(self, cylinder_relative_size: float = 0.008, orientation_relative_size: float = 0.05):
         self.ax.clear()
 
         # plot the arm
@@ -154,36 +154,38 @@ class RobotSerial(Robot):
         plot_size = self.plot_settings()
 
         # plot axes using cylinders
-        cy_radius = plot_size / 100
-        cy_len = cy_radius * 10.
-        cy_div = 11
-        theta = np.linspace(0, 2 * np.pi, cy_div)
-        cx = np.array([cy_radius * np.cos(theta)])
-        cz = np.array([-0.5 * cy_len, 0.5 * cy_len])
-        cx, cz = np.meshgrid(cx, cz)
-        cy = np.array([cy_radius * np.sin(theta)] * 2)
-        points = np.zeros([3, cy_div * 2])
-        points[0] = cx.flatten()
-        points[1] = cy.flatten()
-        points[2] = cz.flatten()
-        self.ax.plot_surface(points[0].reshape(2, cy_div), points[1].reshape(2, cy_div), points[2].reshape(2, cy_div),
-                             color="pink", rstride=1, cstride=1, linewidth=0, alpha=0.4)
-        for i in range(n_lines - 1):
-            f = axis_frames[i]
-            points_f = f.r_3_3.dot(points) + f.t_3_1
-            self.ax.plot_surface(points_f[0].reshape(2, cy_div),
-                                 points_f[1].reshape(2, cy_div),
-                                 points_f[2].reshape(2, cy_div),
-                                 color="pink", rstride=1, cstride=1, linewidth=0, alpha=0.4)
+        if cylinder_relative_size > 0:
+            cy_radius = plot_size * cylinder_relative_size
+            cy_len = cy_radius * 7.
+            cy_div = 11
+            theta = np.linspace(0, 2 * np.pi, cy_div)
+            cx = np.array([cy_radius * np.cos(theta)])
+            cz = np.array([-0.5 * cy_len, 0.5 * cy_len])
+            cx, cz = np.meshgrid(cx, cz)
+            cy = np.array([cy_radius * np.sin(theta)] * 2)
+            points = np.zeros([3, cy_div * 2])
+            points[0] = cx.flatten()
+            points[1] = cy.flatten()
+            points[2] = cz.flatten()
+            self.ax.plot_surface(points[0].reshape(2, cy_div), points[1].reshape(2, cy_div), points[2].reshape(2, cy_div),
+                                 color="pink", rstride=1, cstride=1, linewidth=0, alpha=0.6)
+            for i in range(n_lines - 1):
+                f = axis_frames[i]
+                points_f = f.r_3_3.dot(points) + f.t_3_1
+                self.ax.plot_surface(points_f[0].reshape(2, cy_div),
+                                     points_f[1].reshape(2, cy_div),
+                                     points_f[2].reshape(2, cy_div),
+                                     color="pink", rstride=1, cstride=1, linewidth=0, alpha=0.6)
 
         # plot the end frame
-        end_pos = axis_frames[-1].t_3_1.flatten()
-        end_rot = axis_frames[-1].r_3_3
-        rotated_x_axis = end_rot[:, 0]
-        rotated_y_axis = end_rot[:, 1]
-        rotated_z_axis = end_rot[:, 2]
-        end_frame_scale = plot_size / 10
-        self.ax.plot(*np.array([end_pos, end_pos + end_frame_scale * rotated_x_axis]).T.tolist(), color="red")
-        self.ax.plot(*np.array([end_pos, end_pos + end_frame_scale * rotated_y_axis]).T.tolist(), color="green")
-        self.ax.plot(*np.array([end_pos, end_pos + end_frame_scale * rotated_z_axis]).T.tolist(), color="blue")
+        if orientation_relative_size > 0:
+            end_frame_scale = plot_size * orientation_relative_size
+            end_pos = axis_frames[-1].t_3_1.flatten()
+            end_rot = axis_frames[-1].r_3_3
+            rotated_x_axis = end_rot[:, 0]
+            rotated_y_axis = end_rot[:, 1]
+            rotated_z_axis = end_rot[:, 2]
+            self.ax.plot(*np.array([end_pos, end_pos + end_frame_scale * rotated_x_axis]).T.tolist(), color="red")
+            self.ax.plot(*np.array([end_pos, end_pos + end_frame_scale * rotated_y_axis]).T.tolist(), color="green")
+            self.ax.plot(*np.array([end_pos, end_pos + end_frame_scale * rotated_z_axis]).T.tolist(), color="blue")
 

--- a/visual_kinematics/RobotSerial.py
+++ b/visual_kinematics/RobotSerial.py
@@ -150,9 +150,11 @@ class RobotSerial(Robot):
             self.ax.plot_wireframe(x[-2:], y[-2:], np.array([z[-2:]]), color="orange")
             self.ax.scatter(x[-1], y[-1], z[-1], c="orange", marker="o")
 
+        # configure plot dimensions dynamically with already printed points and get plot_size
+        plot_size = self.plot_settings()
+
         # plot axes using cylinders
-        axes_scale = max(max(np.abs(x)), max(np.abs(y)), max(np.abs(z))) / 5000
-        cy_radius = np.amax(self.params[:, 0:2]) * axes_scale
+        cy_radius = plot_size / 50
         cy_len = cy_radius * 4.
         cy_div = 11
         theta = np.linspace(0, 2 * np.pi, cy_div)
@@ -180,9 +182,8 @@ class RobotSerial(Robot):
         rotated_x_axis = end_rot[:, 0]
         rotated_y_axis = end_rot[:, 1]
         rotated_z_axis = end_rot[:, 2]
-        end_frame_scale = max(np.abs(end_pos)) / 10
+        end_frame_scale = plot_size / 10
         self.ax.plot(*np.array([end_pos, end_pos + end_frame_scale * rotated_x_axis]).T.tolist(), color="red")
         self.ax.plot(*np.array([end_pos, end_pos + end_frame_scale * rotated_y_axis]).T.tolist(), color="green")
         self.ax.plot(*np.array([end_pos, end_pos + end_frame_scale * rotated_z_axis]).T.tolist(), color="blue")
 
-        self.plot_settings()

--- a/visual_kinematics/RobotSerial.py
+++ b/visual_kinematics/RobotSerial.py
@@ -98,8 +98,11 @@ class RobotSerial(Robot):
             return self.inverse_numerical(end_frame)
 
     def inverse_analytical(self, end_frame, method):
-        # TODO give tool to method
-        self.is_reachable_inverse, theta_x = method(self.dh_params, end_frame)
+        if self.tool is None:
+            self.is_reachable_inverse, theta_x = method(self.dh_params, end_frame)
+        else:
+            self.is_reachable_inverse, theta_x = method(self.dh_params, self.tool, end_frame)
+
         self.forward(theta_x)
         return theta_x
 

--- a/visual_kinematics/RobotSerial.py
+++ b/visual_kinematics/RobotSerial.py
@@ -1,9 +1,10 @@
+import logging
+
 import numpy as np
 
-from visual_kinematics.Robot import Robot
 from visual_kinematics.Frame import Frame
+from visual_kinematics.Robot import Robot
 from visual_kinematics.utility import simplify_angles
-import logging
 
 
 class RobotSerial(Robot):

--- a/visual_kinematics/RobotTrajectory.py
+++ b/visual_kinematics/RobotTrajectory.py
@@ -1,6 +1,8 @@
+import numpy as np
+from matplotlib import pyplot as plt
 from matplotlib.widgets import Slider
 
-from visual_kinematics.Robot import *
+from visual_kinematics.Frame import Frame
 
 
 class RobotTrajectory(object):

--- a/visual_kinematics/RobotTrajectory.py
+++ b/visual_kinematics/RobotTrajectory.py
@@ -83,11 +83,15 @@ class RobotTrajectory(object):
         return inter_values, inter_time_points
 
     def show(self, num_segs=100, motion="p2p", method="linear"):
+        inter_values, inter_time_points, slider = self.draw(num_segs, motion, method)
+        plt.show()
+        return inter_values, inter_time_points
+
+    def draw(self, num_segs=100, motion="p2p", method="linear"):
         # interpolation values
         inter_values, inter_time_points = self.interpolate(num_segs, motion, method)
         slider = self.draw_from_joint_positions(self.robot, inter_values)
-        plt.show()
-        return inter_values, inter_time_points
+        return inter_values, inter_time_points, slider
 
     @staticmethod
     def draw_from_joint_positions(robot, joint_positions):

--- a/visual_kinematics/RobotTrajectory.py
+++ b/visual_kinematics/RobotTrajectory.py
@@ -1,8 +1,6 @@
-import numpy as np
+from matplotlib.widgets import Slider
 
 from visual_kinematics.Robot import *
-from mpl_toolkits.mplot3d import Axes3D
-from matplotlib.widgets import Slider
 
 
 class RobotTrajectory(object):

--- a/visual_kinematics/RobotTrajectory.py
+++ b/visual_kinematics/RobotTrajectory.py
@@ -83,30 +83,40 @@ class RobotTrajectory(object):
         return inter_values, inter_time_points
 
     def show(self, num_segs=100, motion="p2p", method="linear"):
-        # setup slider
-        axamp = plt.axes([0.15, .06, 0.75, 0.02])
-        samp = Slider(axamp, "progress", 0., 1., valinit=0)
         # interpolation values
         inter_values, inter_time_points = self.interpolate(num_segs, motion, method)
-        # save point for drawing trajectory
-        x, y, z = [], [], []
-        for i in range(num_segs + 1):
-            self.robot.forward(inter_values[i])
-            x.append(self.robot.end_frame.t_3_1[0, 0])
-            y.append(self.robot.end_frame.t_3_1[1, 0])
-            z.append(self.robot.end_frame.t_3_1[2, 0])
-
-        def update(val):
-            self.robot.forward(inter_values[int(np.floor(samp.val * num_segs))])
-            self.robot.draw()
-            # plot trajectory
-            self.robot.ax.plot_wireframe(x, y, np.array([z]), color="lightblue")
-            self.robot.figure.canvas.draw_idle()
-
-        samp.on_changed(update)
-        # plot initial
-        self.robot.forward(inter_values[0])
-        self.robot.draw()
-        self.robot.ax.plot_wireframe(x, y, np.array([z]), color="lightblue")
+        slider = self.draw_from_joint_positions(self.robot, inter_values)
         plt.show()
         return inter_values, inter_time_points
+
+    @staticmethod
+    def draw_from_joint_positions(robot, joint_positions):
+        num_segs = len(joint_positions)
+
+        # setup slider
+        ax_slider = plt.axes([0.15, .06, 0.75, 0.02])
+        slider = Slider(ax_slider, "progress", 0., 1., valinit=0)
+
+        # save point for drawing trajectory
+        x, y, z = [], [], []
+        for i in range(num_segs):
+            robot.forward(joint_positions[i])
+            x.append(robot.end_frame.t_3_1[0, 0])
+            y.append(robot.end_frame.t_3_1[1, 0])
+            z.append(robot.end_frame.t_3_1[2, 0])
+
+        def update(_):
+            position_index = int(slider.val * (num_segs - 1))
+            robot.forward(joint_positions[position_index])
+            robot.draw()
+            # plot trajectory
+            robot.ax.plot_wireframe(x, y, np.array([z]), color="lightblue")
+            robot.figure.canvas.draw_idle()
+
+        slider.on_changed(update)
+        # plot initial
+        robot.forward(joint_positions[0])
+        robot.draw()
+        robot.ax.plot_wireframe(x, y, np.array([z]), color="lightblue")
+
+        return slider

--- a/visual_kinematics/Tool.py
+++ b/visual_kinematics/Tool.py
@@ -1,0 +1,13 @@
+from visual_kinematics.Frame import Frame
+
+
+class Tool(Frame):
+    # ================== Definition and Kinematics
+    # init tool via definition as frame
+    # ==================
+    def __init__(self, t_4_4, name: str = ''):
+        super().__init__(t_4_4)
+        self.name: str = name
+
+    def set_tool_name(self, name: str = ''):
+        self.name = name

--- a/visual_kinematics/Tool.py
+++ b/visual_kinematics/Tool.py
@@ -3,7 +3,8 @@ from visual_kinematics.Frame import Frame
 
 class Tool(Frame):
     # ================== Definition and Kinematics
-    # init tool via definition as frame
+    # a tool is defined by its translation matrix
+    # object is derived from Frame and hence support all its operations
     # ==================
     def __init__(self, t_4_4, name: str = ''):
         super().__init__(t_4_4)

--- a/visual_kinematics/utility.py
+++ b/visual_kinematics/utility.py
@@ -1,4 +1,3 @@
-import numpy as np
 from math import pi
 
 


### PR DESCRIPTION
Hi :)

I was using your toolbox for visualizing robot movements of a ur5 serial robot and had the problem that the toolbox did not support visualizing the displacement of the tcp when using a tool at the end effector.
For that I added an implementation enabling specifying a tool via a Tool object (basically just a Frame).
On my way I also fixed a few visualization bugs that occured when displaying a robot with large dimensions (e.g. when the dh are in mm instead of m). Also you can now use the default matplotlib scaling, but with equally spaced axes (behaviour is a bit wonky for trajectories though).
Also added some tests and examples.
Use whatever you want to include in your repo :)

Best Regards
Tobi